### PR TITLE
Bump shell-version for GNOME 43 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,6 @@
   "description": "Hides the classic title bar of maximized X.Org windows",
   "url": "https://github.com/alecdotninja/no-titlebar-when-maximized",
   "uuid": "no-titlebar-when-maximized@alec.ninja",
-  "shell-version": ["41", "42"],
-  "version": 5
+  "shell-version": ["41", "42", "43"],
+  "version": 6
 }


### PR DESCRIPTION
Tested on GNOME 43.0 / Debian Testing.

Fixes #7 