### PR TITLE
Add 'unlock-dialog' to prevent disable() call when the screen is locked

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,5 +4,6 @@
   "url": "https://github.com/alecdotninja/no-titlebar-when-maximized",
   "uuid": "no-titlebar-when-maximized@alec.ninja",
   "shell-version": ["45", "46"],
-  "version": 15
+  "session-modes" : ["user", "unlock-dialog"],
+  "version": 16
 }


### PR DESCRIPTION
This prevents windows from being unmaximised after locking and unlocking the screen. Locking the screen disabled the extension, which reset the window. Adding 'unlock-dialog' to session-modes (which defaults to just ['user']) allows the extension to keep running.

See: https://stackoverflow.com/questions/47008276/gnome-shell-extensions-preventing-the-call-of-disable-when-the-screen-gets-lo

While the docs linked in the bottom answer say extensions with both 'user' and 'unlock-dialog' should still be prepared to receive calls to disable() and enabled() when the mode changes, on my system (Fedora 40) this doesn't happen as long as it switched between those two.