### PR TITLE
revert #22 and declare v48 compatibility

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,6 @@
   "description": "Hides the classic title bar of maximized X.Org windows",
   "url": "https://github.com/alecdotninja/no-titlebar-when-maximized",
   "uuid": "no-titlebar-when-maximized@alec.ninja",
-  "shell-version": ["45", "46", "47"],
-  "session-modes": ["user", "unlock-dialog"],
-  "version": 17
+  "shell-version": ["45", "46", "47", "48"],
+  "version": 18
 }


### PR DESCRIPTION
Since the introduction of #22 prevents the extension from being submitted as is, this PR proposes to revert it so that it can be submitted again, and #22 can be reworked from a draft if needed (I couldn't reproduce the original issue, windows stay maximized after locking and unlocking the screen).

Also since the extension works wonderfully with gnome 48, this PR declares this extension as v48 compatible

closes #25 